### PR TITLE
Switch to readable ABI

### DIFF
--- a/codegen.js
+++ b/codegen.js
@@ -3,6 +3,7 @@
 const path = require('node:path');
 const fs = require('node:fs/promises');
 const prettier = require('prettier');
+const ethers = require('ethers');
 
 const ABI_WHITELIST = {
   CoreProxy: {
@@ -22,6 +23,11 @@ async function prettyJs(content) {
     parser: 'acorn',
     ...prettierOptions,
   });
+}
+
+function readableAbi(abi) {
+  const iface = new ethers.utils.Interface(abi);
+  return iface.format(ethers.utils.FormatTypes.full);
 }
 
 async function codegen() {
@@ -83,7 +89,7 @@ async function codegen() {
         `./lib/deployments/${chainId}-${preset}/${contractName}.js`,
         await prettyJs(`
           exports.address = ${JSON.stringify(address)};
-          exports.abi = ${JSON.stringify(abi)};
+          exports.abi = ${JSON.stringify(readableAbi(abi))};
         `),
         'utf8'
       );

--- a/lib/deployments/1-main/AccountProxy.js
+++ b/lib/deployments/1-main/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0x0E429603D3Cb1DFae4E6F52Add5fE82d96d77Dac';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/1-main/CoreProxy.js
+++ b/lib/deployments/1-main/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0xffffffaEff0B96Ea8e4f94b2253f31abdD875847';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/10-main/AccountProxy.js
+++ b/lib/deployments/10-main/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0x0E429603D3Cb1DFae4E6F52Add5fE82d96d77Dac';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/10-main/CoreProxy.js
+++ b/lib/deployments/10-main/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0xffffffaEff0B96Ea8e4f94b2253f31abdD875847';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/11155111-main/AccountProxy.js
+++ b/lib/deployments/11155111-main/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0xe487Ad4291019b33e2230F8E2FB1fb6490325260';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/11155111-main/CoreProxy.js
+++ b/lib/deployments/11155111-main/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0x76490713314fCEC173f44e99346F54c6e92a8E42';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/420-main/AccountProxy.js
+++ b/lib/deployments/420-main/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0x1b791d05E437C78039424749243F5A79E747525e';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/420-main/CoreProxy.js
+++ b/lib/deployments/420-main/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0x76490713314fCEC173f44e99346F54c6e92a8E42';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/5-main/AccountProxy.js
+++ b/lib/deployments/5-main/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0xf19BdaE737d61A91cd0aeb3E32D0E11f9eF7aE5c';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/5-main/CoreProxy.js
+++ b/lib/deployments/5-main/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0x895CE54BBA4f14FeFbF0624673DC303054De0652';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/8453-andromeda/AccountProxy.js
+++ b/lib/deployments/8453-andromeda/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0x63f4Dd0434BEB5baeCD27F3778a909278d8cf5b8';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/8453-andromeda/CoreProxy.js
+++ b/lib/deployments/8453-andromeda/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0x32C222A9A159782aFD7529c87FA34b96CA72C696';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/84531-andromeda/AccountProxy.js
+++ b/lib/deployments/84531-andromeda/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0xa88694d0025dd96194D1B0237fDEbf7D1D34B02F';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/84531-andromeda/CoreProxy.js
+++ b/lib/deployments/84531-andromeda/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0xF4Df9Dd327Fd30695d478c3c8a2fffAddcdD0d31';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];

--- a/lib/deployments/84532-andromeda/AccountProxy.js
+++ b/lib/deployments/84532-andromeda/AccountProxy.js
@@ -1,24 +1,5 @@
 exports.address = '0xa88694d0025dd96194D1B0237fDEbf7D1D34B02F';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'address', name: 'holder' }],
-    outputs: [{ type: 'uint256', name: 'balance' }],
-  },
-  {
-    type: 'function',
-    name: 'tokenOfOwnerByIndex',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [
-      { type: 'address', name: 'owner' },
-      { type: 'uint256', name: 'index' },
-    ],
-    outputs: [{ type: 'uint256' }],
-  },
+  'function balanceOf(address holder) view returns (uint256 balance)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
 ];

--- a/lib/deployments/84532-andromeda/CoreProxy.js
+++ b/lib/deployments/84532-andromeda/CoreProxy.js
@@ -1,28 +1,6 @@
 exports.address = '0xF4Df9Dd327Fd30695d478c3c8a2fffAddcdD0d31';
 exports.abi = [
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [],
-    outputs: [{ type: 'uint128', name: 'accountId' }],
-  },
-  {
-    type: 'function',
-    name: 'createAccount',
-    constant: false,
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'requestedAccountId' }],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'getAccountOwner',
-    constant: true,
-    stateMutability: 'view',
-    payable: false,
-    inputs: [{ type: 'uint128', name: 'accountId' }],
-    outputs: [{ type: 'address' }],
-  },
+  'function createAccount() returns (uint128 accountId)',
+  'function createAccount(uint128 requestedAccountId)',
+  'function getAccountOwner(uint128 accountId) view returns (address)',
 ];


### PR DESCRIPTION
Because both ethers and viem support readable ABI out of box

https://viem.sh/docs/ethers-migration#interfaceformat

<img width="732" alt="image" src="https://github.com/Synthetixio/v3-hooks/assets/28145325/75a21112-cda6-4ef0-a0c1-4cc0434fd306">
